### PR TITLE
Get file path from 'data-path' attribute to get absolute path when file path is too large

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -96,7 +96,8 @@ function buildTree() {
                             .split(' & ');
         var pathString = $(item).find('a')[0];
         var pathLink = pathString.getAttribute("href");
-        var itemSplitted = pathString.text.split('/');
+        var filePath = $(item).parent('.file-header').data('path');
+        var itemSplitted = filePath.split('/');
 
         var nodeObj = {};
         var nodeObjJoker = nodeObj;


### PR DESCRIPTION
Hi @picheli20 ,

Thank you so much for your repo, that's a great way to review PRs.

I've found only a small mistake when you retrieve the file path because I proof with large file paths and if you use the text name of the link, you retrieve something like `.../xxx/xxxx`. So using the `data-path` attribute from parent div you get the absolute path :)

Regards