### PR TITLE
Improved visibility on unified view

### DIFF
--- a/app/style.js
+++ b/app/style.js
@@ -1,7 +1,7 @@
 function injectCss(offsetTop, offsetLeft) {
     $('#gct-style').remove();
     $(`<style type='text/css' id="gct-style">
-        #files {
+        body.full-width #files {
             margin-left: 300px;
         }
 
@@ -74,6 +74,7 @@ function injectCss(offsetTop, offsetLeft) {
             cursor: pointer;
         }
 
+        body:not(.full-width) .gct-file-tree,
         .gct-file-tree-fixed {
             position: fixed;
             top: 70px;


### PR DESCRIPTION
The "Unified diff view" gets too squished when this extension is enabled. This PR changes the layout in the unified view so the content is unaffected.
The Split view is not altered by this PR, it looks fine as it is now.

Current behaviour:
![image](https://user-images.githubusercontent.com/5365487/37955164-2534fcae-31a8-11e8-9de9-02e379ed12c3.png)
![image](https://user-images.githubusercontent.com/5365487/37955277-74e393a0-31a8-11e8-8bdb-aa9bce2c19e5.png)

This PR behaviour:
![image](https://user-images.githubusercontent.com/5365487/37955325-97a56b16-31a8-11e8-89ad-62a5405c6613.png)

It does look a bit broken, as it just basically position:fixes it right from the start, but I rather this way than taking 50% of the diff space.