### PR TITLE
Fix URL RegExp to match git repo name with underscore

### DIFF
--- a/app/background/index.js
+++ b/app/background/index.js
@@ -107,7 +107,7 @@ const start = () => setInterval(() => {
     const regex = customRegex || '(http|https):\\/\\/(www\\.)?github[\\.]?[-a-zA-Z0-9]*\\.com';
 
     if(!$('.gct-file-tree').length) {
-      urlPullRegex = RegExp(`${regex}\\/[-a-zA-Z0-9]*\\/[-a-zA-Z0-9]*\\/pull\\/[0-9]*\\/(files|commits)`);
+      urlPullRegex = RegExp(`${regex}\\/[-a-zA-Z0-9-_]*\\/[-a-zA-Z0-9-_]*\\/pull\\/[0-9]*\\/(files|commits)`);
       urlCommitRegex = RegExp(`${regex}\\/[-a-zA-Z0-9]*\\/[-a-zA-Z0-9]*\\/commit`);
 
       isCommit = location.href.match(urlCommitRegex);


### PR DESCRIPTION
To work with repo name like `https://github.com/XX_YYYY_repo/some_app/pull/7022/files`

![image](https://user-images.githubusercontent.com/7699445/55253049-8624ef80-5211-11e9-846f-976f0ca55d7c.png)
